### PR TITLE
adjustments for latest backend and community server

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --host 127.0.0.1 --disable-host-check true",
     "start:ssl": "ng serve --ssl",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",

--- a/src/app/views/navbar/navbar.component.ts
+++ b/src/app/views/navbar/navbar.component.ts
@@ -27,6 +27,9 @@ export class NavbarComponent implements OnInit {
 
     const options = {
       method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
       body: JSON.stringify({idp: 'http://localhost:3000/'}),
     } as RequestInit;
 
@@ -40,4 +43,3 @@ export class NavbarComponent implements OnInit {
     }
   }
 }
-

--- a/src/assets/id.jsonld
+++ b/src/assets/id.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": "https://www.w3.org/ns/solid/oidc-context.jsonld",
-  "client_id":"http://localhost:4200/assets/id",
+  "client_id":"http://localhost:4200/assets/id.jsonld",
   "redirect_uris":[
     "http://localhost:4200",
     "http://localhost:4200/",

--- a/src/assets/id.jsonld
+++ b/src/assets/id.jsonld
@@ -1,5 +1,5 @@
 {
-  "@context": "http://www.w3.org/ns/solid/oidc-context.jsonld",
+  "@context": "https://www.w3.org/ns/solid/oidc-context.jsonld",
   "client_id":"http://localhost:4200/assets/id",
   "redirect_uris":[
     "http://localhost:4200",

--- a/src/assets/id.jsonld
+++ b/src/assets/id.jsonld
@@ -1,6 +1,6 @@
 {
-  "@context": "https://www.w3.org/ns/solid/oidc-context.jsonld",
-  "client_id":"https://localhost:4200/assets/id",
+  "@context": "http://www.w3.org/ns/solid/oidc-context.jsonld",
+  "client_id":"http://localhost:4200/assets/id",
   "redirect_uris":[
     "http://localhost:4200",
     "http://localhost:4200/",

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,10 +4,10 @@
 
 export const ENV = {
   production: false,
-  OIDC_CLIENT_ID: 'https://localhost:4200/assets/id',
-  BASE_URL: 'https://localhost:4200',
+  OIDC_CLIENT_ID: 'http://localhost:4200/assets/id.jsonld',
+  BASE_URL: 'http://localhost:4200',
   SRV_BASE: 'http://localhost:4000',
-  API_URL: 'https://localhost:4200/api',
+  API_URL: 'http://localhost:4200/api',
   DEFAULT_IDP: 'http://localhost:3000/',
 };
 


### PR DESCRIPTION
We needed to make some changes to get it working with the latest backend and community server.

1. `loginServer()` uses expected content type
2. ClientID Document has `.jsonld` extension to be served with correct content type (community server fails to parse otherwise), adjusted `OIDC_CLIENT_ID
3. `--host 127.0.0.1` made it work on MacOS with community server run locally, not sure if `--disable-host-check true` is needed
4. removed all https to avoid any SSL issues, some of that might needed to be reverted.