### PR TITLE
bootstrapped authorization view

### DIFF
--- a/src/app/actions/core.actions.ts
+++ b/src/app/actions/core.actions.ts
@@ -46,6 +46,11 @@ const serverSessionReceived = createAction(
   props<{isServerLoggedIn: boolean, redirectUrl?: string}>(),
 )
 
+const pathRequested = createAction(
+  '[CORE] Path requested',
+  props<{requestedPath: string}>()
+)
+
 const requestName = createAction(
   '[CORE] Request Name',
 )
@@ -70,6 +75,7 @@ export const CoreActions = {
   loginStatusChanged,
   serverSessionRequested,
   serverSessionReceived,
+  pathRequested,
   requestName,
   serverLoginRequested,
   serverLoginInitiated

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,6 +4,7 @@ import {LoginComponent} from "./components/login/login.component";
 import {DashboardComponent} from "./components/dashboard/dashboard.component";
 import {AuthGuard} from "./guards/auth.guard.service";
 import {RedirectHandlerComponent} from "./components/redirect-handler/redirect-handler.component";
+import {AuthorizationComponent} from "./components/authorization/authorization.component";
 
 const routes: Routes = [
   {
@@ -14,6 +15,10 @@ const routes: Routes = [
   },
   {
     path: 'redirect', component: RedirectHandlerComponent,
+  },
+  {
+    path: 'authorize', component: AuthorizationComponent, canActivate: [AuthGuard],
+
   },
 ];
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -27,6 +27,7 @@ import {MatIconModule} from "@angular/material/icon";
 import { FormsModule } from "@angular/forms";
 import { RedirectHandlerComponent } from './components/redirect-handler/redirect-handler.component';
 import {SolidClient} from "./utils/solid-client";
+import { AuthorizationComponent } from './components/authorization/authorization.component';
 
 @NgModule({
   declarations: [
@@ -36,6 +37,7 @@ import {SolidClient} from "./utils/solid-client";
     DashboardComponent,
     ConsentPanelComponent,
     RedirectHandlerComponent,
+    AuthorizationComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/authorization/authorization.component.html
+++ b/src/app/components/authorization/authorization.component.html
@@ -1,0 +1,3 @@
+<pre>
+  {{ descriptions$ | async | json}}
+</pre>

--- a/src/app/components/authorization/authorization.component.spec.ts
+++ b/src/app/components/authorization/authorization.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AuthorizationComponent } from './authorization.component';
+
+describe('AuthorizationComponent', () => {
+  let component: AuthorizationComponent;
+  let fixture: ComponentFixture<AuthorizationComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AuthorizationComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AuthorizationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/authorization/authorization.component.ts
+++ b/src/app/components/authorization/authorization.component.ts
@@ -1,0 +1,34 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import {Store} from "@ngrx/store";
+import { DescActions } from 'src/app/actions/description.actions';
+import { selectDescriptions } from 'src/app/selectors/description.selectors'
+
+@Component({
+  selector: 'sai-authorization',
+  templateUrl: './authorization.component.html',
+  styleUrls: ['./authorization.component.scss']
+})
+export class AuthorizationComponent implements OnInit {
+
+  descriptions$ = this.store.select(selectDescriptions)
+
+  constructor(
+    private route: ActivatedRoute,
+    private store: Store,
+    ) { }
+
+  ngOnInit(): void {
+    const clientId = this.route.snapshot.queryParamMap.get('client_id')
+    // TODO move language into core state?
+    if (clientId) {
+      this.store.dispatch(DescActions.descriptionsNeeded({
+        applicationId: clientId,
+        lang: 'en'
+      }))
+    } else {
+      throw new Error('authorization requires client_id query parameter')
+    }
+  }
+
+}

--- a/src/app/guards/auth.guard.service.ts
+++ b/src/app/guards/auth.guard.service.ts
@@ -1,16 +1,11 @@
 import {Injectable} from '@angular/core';
 import {ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree} from '@angular/router';
-import {from, map, Observable} from 'rxjs';
+import {tap, from, map, Observable} from 'rxjs';
 import {getDefaultSession, onSessionRestore} from '@inrupt/solid-client-authn-browser';
 import {Store} from "@ngrx/store";
 import {loggedInStatus} from "../selectors";
 import {mergeMap} from "rxjs/operators";
 import {CoreActions} from "../actions";
-
-
-onSessionRestore((currentUrl: string) => {
-  console.log('ON SESSION RESTORE', currentUrl);
-})
 
 @Injectable({
   providedIn: 'root'
@@ -20,7 +15,13 @@ export class AuthGuard implements CanActivate {
   constructor(
     private router: Router,
     private store: Store,
-  ) {}
+  ) {
+    onSessionRestore((currentUrl: string) => {
+      const url = new URL(currentUrl)
+      const requestedPath = url.pathname + url.search
+      this.store.dispatch(CoreActions.pathRequested({ requestedPath }))
+    })
+  }
 
   canActivate(
     route: ActivatedRouteSnapshot,

--- a/src/app/reducers/core.reducer.ts
+++ b/src/app/reducers/core.reducer.ts
@@ -9,6 +9,7 @@ export interface CoreState {
   isLoggedIn: boolean;
   isServerLoggedIn: boolean;
   redirectUrl: string;
+  requestedPath: string;
 }
 
 export const initialState: CoreState = {
@@ -17,6 +18,7 @@ export const initialState: CoreState = {
   isLoggedIn: false,
   isServerLoggedIn: false,
   redirectUrl: '',
+  requestedPath: '/',
 }
 
 export const coreReducer = createReducer(
@@ -24,5 +26,6 @@ export const coreReducer = createReducer(
   on(CoreActions.loginInitiated, (state, {oidcIssuer}) => ({...state, oidcIssuer})),
   on(CoreActions.webIdReceived, (state, {webId}) => ({...state, webId})),
   on(CoreActions.loginStatusChanged, (state, {loggedIn}) => ({...state, isLoggedIn: loggedIn})),
-  on(CoreActions.serverSessionReceived, (state, {isServerLoggedIn, redirectUrl}) => ({...state, isServerLoggedIn, redirectUrl: redirectUrl ? redirectUrl : ''}))
+  on(CoreActions.serverSessionReceived, (state, {isServerLoggedIn, redirectUrl}) => ({...state, isServerLoggedIn, redirectUrl: redirectUrl ? redirectUrl : ''})),
+  on(CoreActions.pathRequested, (state, {requestedPath}) => ({...state, requestedPath}))
 )

--- a/src/app/selectors/ core.selectors.ts
+++ b/src/app/selectors/ core.selectors.ts
@@ -28,3 +28,8 @@ export const serverLoggedInStatus = createSelector(
   selectCore,
   core => core.isServerLoggedIn,
 )
+
+export const requestedPath = createSelector(
+  selectCore,
+  core => core.requestedPath,
+);

--- a/src/app/selectors/description.selectors.ts
+++ b/src/app/selectors/description.selectors.ts
@@ -1,0 +1,9 @@
+import {createFeatureSelector, createSelector} from "@ngrx/store";
+import {DESCRIPTIONS_STATE_KEY, DescriptionsState} from "../reducers/descriptions.reducer";
+
+export const selectDescriptionsFeature = createFeatureSelector<DescriptionsState>(DESCRIPTIONS_STATE_KEY);
+
+export const selectDescriptions = createSelector(
+  selectDescriptionsFeature,
+  state => ([...Object.values(state.byId)]),
+)


### PR DESCRIPTION
can be tested by visiting http://localhost:4200/authorize?client_id=http://localhost:3000/acme/projectron/id

it is coupled with [FRONTEND_AUTHORIZATION_URL](https://github.com/janeirodigital/sai-impl-service/blob/main/packages/service/.env#L7) env variable on the backend

apps (clients) can discover it as [`authorization_redirect_uri`](https://github.com/janeirodigital/sai-impl-service/blob/main/packages/service/src/handlers/agents-handler.ts#L59) in authorization agent's Client ID document.

apps need to add query parameter `client_id` using its client_id