### PR TITLE
added StartGuard and changed routing

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,25 +1,46 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import {StartComponent} from "./components/start/start.component";
 import {LoginComponent} from "./components/login/login.component";
+import {ConnectServerComponent} from "./components/connect-server/connect-server.component";
 import {DashboardComponent} from "./components/dashboard/dashboard.component";
+import {StartGuard} from "./guards/start.guard";
 import {AuthGuard} from "./guards/auth.guard.service";
 import {RedirectHandlerComponent} from "./components/redirect-handler/redirect-handler.component";
 import {AuthorizationComponent} from "./components/authorization/authorization.component";
 
 const routes: Routes = [
   {
-    path: '', component: DashboardComponent, canActivate: [AuthGuard],
-  },
-  {
-    path: 'login', component: LoginComponent,
-  },
-  {
-    path: 'redirect', component: RedirectHandlerComponent,
-  },
-  {
-    path: 'authorize', component: AuthorizationComponent, canActivate: [AuthGuard],
+    path: '',
+    canActivateChild: [StartGuard] ,
+    children: [
+      {
+        path: 'start', component: StartComponent,
+      },
+      {
+        path: 'login', component: LoginComponent,
+      },
+      {
+        path: 'redirect', component: RedirectHandlerComponent,
+      },
+      {
+        path: 'connect', component: ConnectServerComponent,
+      },
 
+    ]
   },
+  {
+    path: '',
+    canActivateChild: [AuthGuard] ,
+    children: [
+      {
+        path: 'dashboard', component: DashboardComponent,
+      },
+      {
+        path: 'authorize', component: AuthorizationComponent,
+      }
+    ]
+  }
 ];
 
 @NgModule({

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,3 @@
 <sai-navbar
-  [oidcIssuer]="(oidcIssuer | async)!"
-  [webId]="(webId | async)!"
-  [isServerLoggedIn]="(isServerLoggedIn | async)!"></sai-navbar>
+  [webId]="(webId | async)!"></sai-navbar>
 <router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,9 @@
 import { Component, OnInit } from '@angular/core';
+import {Router} from "@angular/router";
 import {Store} from "@ngrx/store";
-import {serverLoggedInStatus, oidcIssuer, webId} from "./selectors";
+import {onSessionRestore} from '@inrupt/solid-client-authn-browser';
 import {CoreActions} from "./actions";
+import {serverLoggedInStatus, oidcIssuer, webId} from "./selectors";
 
 @Component({
   selector: 'app-root',
@@ -15,9 +17,21 @@ export class AppComponent implements OnInit{
   isServerLoggedIn = this.store.select(serverLoggedInStatus);
 
   constructor(
+    private router: Router,
     private store: Store,
-  ) {}
+  ) {
+    // TODO ensure that requestedPath gets set even if oidc session can't be restored
+    onSessionRestore((currentUrl: string) => {
+      const url = new URL(currentUrl)
+      let requestedPath = url.pathname + url.search
+      this.store.dispatch(CoreActions.pathRequested({ requestedPath }))
+    })
+  }
 
   ngOnInit() {
+    // '/' doesn't trigger any guards and we want to trigger start guard
+    if (window.location.pathname === '/') {
+      this.router.navigateByUrl('/start')
+    }
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -28,6 +28,9 @@ import { FormsModule } from "@angular/forms";
 import { RedirectHandlerComponent } from './components/redirect-handler/redirect-handler.component';
 import {SolidClient} from "./utils/solid-client";
 import { AuthorizationComponent } from './components/authorization/authorization.component';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import { StartComponent } from './components/start/start.component';
+import { ConnectServerComponent } from './components/connect-server/connect-server.component';
 
 @NgModule({
   declarations: [
@@ -38,6 +41,8 @@ import { AuthorizationComponent } from './components/authorization/authorization
     ConsentPanelComponent,
     RedirectHandlerComponent,
     AuthorizationComponent,
+    StartComponent,
+    ConnectServerComponent,
   ],
   imports: [
     BrowserModule,
@@ -52,6 +57,7 @@ import { AuthorizationComponent } from './components/authorization/authorization
     MatInputModule,
     MatIconModule,
     MatExpansionModule,
+    MatProgressSpinnerModule,
     FormsModule,
     StoreModule.forRoot(reducers, {
       metaReducers

--- a/src/app/components/connect-server/connect-server.component.html
+++ b/src/app/components/connect-server/connect-server.component.html
@@ -1,0 +1,1 @@
+<button mat-raised-button (click)="loginServer()">Connect To Server</button>

--- a/src/app/components/connect-server/connect-server.component.spec.ts
+++ b/src/app/components/connect-server/connect-server.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConnectServerComponent } from './connect-server.component';
+
+describe('ConnectServerComponent', () => {
+  let component: ConnectServerComponent;
+  let fixture: ComponentFixture<ConnectServerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ConnectServerComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ConnectServerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/connect-server/connect-server.component.ts
+++ b/src/app/components/connect-server/connect-server.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit } from '@angular/core';
+import { Store } from '@ngrx/store'
+import { CoreActions } from 'src/app/actions';
+
+@Component({
+  selector: 'sai-connect-server',
+  templateUrl: './connect-server.component.html',
+  styleUrls: ['./connect-server.component.scss']
+})
+export class ConnectServerComponent implements OnInit {
+
+  constructor(
+    private store: Store,
+  ) {}
+
+  ngOnInit(): void {
+  }
+
+  loginServer() {
+    this.store.dispatch(CoreActions.serverLoginRequested())
+  }
+}

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -18,7 +18,7 @@ export class LoginComponent implements OnInit {
 
   constructor(
     private store: Store,
-  ) { }
+  ) {}
 
   ngOnInit(): void {}
 

--- a/src/app/components/redirect-handler/redirect-handler.component.ts
+++ b/src/app/components/redirect-handler/redirect-handler.component.ts
@@ -2,8 +2,6 @@ import {Component, OnInit} from '@angular/core';
 import {Router} from "@angular/router";
 import {Store} from "@ngrx/store";
 import {CoreActions} from "../../actions";
-import {Subscription} from "rxjs";
-import {loggedInStatus, requestedPath} from "../../selectors";
 
 @Component({
   selector: 'sai-redirect-handler',
@@ -11,30 +9,14 @@ import {loggedInStatus, requestedPath} from "../../selectors";
   styleUrls: ['./redirect-handler.component.scss']
 })
 export class RedirectHandlerComponent implements OnInit {
-  loggedInStatus$ = this.store.select(loggedInStatus)
-  requestedPath$ = this.store.select(requestedPath)
-  isLoggedInSubscription?: Subscription
-  requestedPathSubscription?: Subscription
 
   constructor(
     private router: Router,
     private store: Store,
-  ) { }
+  ) {}
 
-  // TODO: handle case of manual navigation to this route
   async ngOnInit(): Promise<void> {
-    this.isLoggedInSubscription = this.loggedInStatus$.subscribe(isLoggedIn => {
-      if (isLoggedIn) {
-      this.requestedPathSubscription = this.requestedPath$.subscribe(path => {
-          this.router.navigateByUrl(path)
-        })
-      }
-    })
     this.store.dispatch(CoreActions.incomingLoginRedirect({url: window.location.href}));
-  }
-
-  OnDestroy() {
-    this.isLoggedInSubscription?.unsubscribe()
-    this.requestedPathSubscription?.unsubscribe()
+    this.router.navigateByUrl('/start')
   }
 }

--- a/src/app/components/start/start.component.html
+++ b/src/app/components/start/start.component.html
@@ -1,0 +1,1 @@
+<mat-spinner></mat-spinner>

--- a/src/app/components/start/start.component.scss
+++ b/src/app/components/start/start.component.scss
@@ -1,0 +1,3 @@
+mat-spinner {
+  margin: 2rem auto;
+}

--- a/src/app/components/start/start.component.spec.ts
+++ b/src/app/components/start/start.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { StartComponent } from './start.component';
+
+describe('StartComponent', () => {
+  let component: StartComponent;
+  let fixture: ComponentFixture<StartComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ StartComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(StartComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/start/start.component.ts
+++ b/src/app/components/start/start.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'sai-start',
+  templateUrl: './start.component.html',
+  styleUrls: ['./start.component.scss']
+})
+export class StartComponent implements OnInit {
+
+  constructor(
+  ) {}
+
+  async ngOnInit(): Promise<void> {
+  }
+}

--- a/src/app/guards/auth.guard.service.ts
+++ b/src/app/guards/auth.guard.service.ts
@@ -1,48 +1,37 @@
 import {Injectable} from '@angular/core';
-import {ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree} from '@angular/router';
-import {tap, from, map, Observable} from 'rxjs';
-import {getDefaultSession, onSessionRestore} from '@inrupt/solid-client-authn-browser';
+import {ActivatedRouteSnapshot, CanActivateChild, Router, RouterStateSnapshot, UrlTree} from '@angular/router';
+import {from, map, Observable} from 'rxjs';
+import {getDefaultSession} from '@inrupt/solid-client-authn-browser';
 import {Store} from "@ngrx/store";
-import {loggedInStatus} from "../selectors";
-import {mergeMap} from "rxjs/operators";
 import {CoreActions} from "../actions";
 
 @Injectable({
   providedIn: 'root'
 })
-export class AuthGuard implements CanActivate {
+export class AuthGuard implements CanActivateChild {
 
   constructor(
     private router: Router,
     private store: Store,
-  ) {
-    onSessionRestore((currentUrl: string) => {
-      const url = new URL(currentUrl)
-      const requestedPath = url.pathname + url.search
-      this.store.dispatch(CoreActions.pathRequested({ requestedPath }))
-    })
-  }
+  ) {}
 
-  canActivate(
+  canActivateChild(
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
 
     return from(this.tryToRecoverSession()).pipe(
-      mergeMap(() =>
-        this.store.select(loggedInStatus) // TODO: login flashes since status changes from false to true
-      ),
-      map(status => status || this.router.parseUrl('login'))
+      map((success) => success || this.router.parseUrl('start'))
     );
   }
 
-  private async tryToRecoverSession(): Promise<void> {
+  private async tryToRecoverSession(): Promise<boolean> {
     const session = getDefaultSession();
 
-    if (session.info.isLoggedIn) {
-      return;
-    } else {
-      const info = await session.handleIncomingRedirect({restorePreviousSession: true});
-      this.store.dispatch(CoreActions.loginStatusChanged({loggedIn: !!info?.isLoggedIn}));
+    if (!session.info.isLoggedIn) {
+      // if sessoin can be restored it will redirect to oidcIssuer, which will return back to `/redirect`
+      await session.handleIncomingRedirect({restorePreviousSession: true});
     }
+    this.store.dispatch(CoreActions.loginStatusChanged({loggedIn: session.info.isLoggedIn}));
+    return session.info.isLoggedIn
   }
 }

--- a/src/app/guards/auth.guard.spec.ts
+++ b/src/app/guards/auth.guard.spec.ts
@@ -40,8 +40,8 @@ describe('Auth Guard', () => {
     })
 
     it('should grant access to any route', (done) => {
-      const canActivate = guard.canActivate(dummyRoute, fakeRouterState('/fakeUrl')) as Observable<boolean>;
-      canActivate.subscribe(r => {
+      const canActivateChild = guard.canActivateChild(dummyRoute, fakeRouterState('/fakeUrl')) as Observable<boolean>;
+      canActivateChild.subscribe(r => {
         expect(r).toBeTrue();
         done();
       })
@@ -55,8 +55,8 @@ describe('Auth Guard', () => {
 
     it('should deny access to any route', (done) => {
       const spy = spyOn(router, 'parseUrl');
-      const canActivate = guard.canActivate(dummyRoute, fakeRouterState('/fakeUrl')) as Observable<UrlTree>;
-      canActivate.subscribe(r => {
+      const canActivateChild = guard.canActivateChild(dummyRoute, fakeRouterState('/fakeUrl')) as Observable<UrlTree>;
+      canActivateChild.subscribe(r => {
         expect(spy).toHaveBeenCalledWith('login');
         done();
       })

--- a/src/app/guards/start.guard.spec.ts
+++ b/src/app/guards/start.guard.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { StartGuard } from './start.guard';
+
+describe('StartGuard', () => {
+  let guard: StartGuard;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    guard = TestBed.inject(StartGuard);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+});

--- a/src/app/guards/start.guard.ts
+++ b/src/app/guards/start.guard.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivateChild, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable, filter, switchMap } from 'rxjs';
+import {Store} from "@ngrx/store";
+import {loginKnown, loggedInStatus, requestedPath, serverLoggedInStatus, redirectUrl} from "../selectors";
+
+@Injectable({
+  providedIn: 'root'
+})
+export class StartGuard implements CanActivateChild {
+
+  constructor(
+    private router: Router,
+    private store: Store,
+  ) {
+    this.store.select(loginKnown).pipe(
+      filter((loginKnown: boolean) => !loginKnown)
+    ).subscribe(() => this.router.navigateByUrl('/dashboard'));
+
+    this.store.select(loginKnown).pipe(
+      filter((loginKnown: boolean) => loginKnown),
+      switchMap(() => this.store.select(loggedInStatus)),
+      filter((loggedIn: boolean) => !loggedIn),
+    ).subscribe(() => this.router.navigateByUrl('/login'));
+
+    this.store.select(loginKnown).pipe(
+      filter((loginKnown: boolean) => loginKnown),
+      switchMap(() => this.store.select(loggedInStatus)),
+      filter((loggedIn: boolean) => loggedIn),
+      switchMap(() => this.store.select(serverLoggedInStatus)),
+      filter((serverLogggedIn: boolean) => !serverLogggedIn),
+      switchMap(() => this.store.select(redirectUrl)),
+      filter((redirectUrl) => !!redirectUrl),
+    ).subscribe(() => this.router.navigateByUrl('/connect'));
+
+    this.store.select(loginKnown).pipe(
+      filter((loginKnown: boolean) => loginKnown),
+      switchMap(() => this.store.select(loggedInStatus)),
+      filter((loggedIn: boolean) => loggedIn),
+      switchMap(() => this.store.select(serverLoggedInStatus)),
+      filter((serverLogggedIn: boolean) => serverLogggedIn),
+      switchMap(() => this.store.select(requestedPath)),
+    ).subscribe((requestedPath) => this.router.navigateByUrl(requestedPath));
+  }
+
+  canActivateChild(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    return true
+  }
+
+}

--- a/src/app/reducers/core.reducer.ts
+++ b/src/app/reducers/core.reducer.ts
@@ -6,6 +6,7 @@ export const CORE_STATE_KEY = 'core';
 export interface CoreState {
   oidcIssuer: string;
   webId: string;
+  loginKnown: boolean;
   isLoggedIn: boolean;
   isServerLoggedIn: boolean;
   redirectUrl: string;
@@ -15,17 +16,23 @@ export interface CoreState {
 export const initialState: CoreState = {
   oidcIssuer: '',
   webId: '',
+  loginKnown: false,
   isLoggedIn: false,
   isServerLoggedIn: false,
   redirectUrl: '',
-  requestedPath: '/',
+  requestedPath: '/dashboard',
 }
+
+const excludedPaths = ['/', '/start', '/redirect', '/login', '/connect']
 
 export const coreReducer = createReducer(
   initialState,
   on(CoreActions.loginInitiated, (state, {oidcIssuer}) => ({...state, oidcIssuer})),
   on(CoreActions.webIdReceived, (state, {webId}) => ({...state, webId})),
-  on(CoreActions.loginStatusChanged, (state, {loggedIn}) => ({...state, isLoggedIn: loggedIn})),
+  on(CoreActions.loginStatusChanged, (state, {loggedIn}) => ({...state, isLoggedIn: loggedIn, loginKnown: true})),
   on(CoreActions.serverSessionReceived, (state, {isServerLoggedIn, redirectUrl}) => ({...state, isServerLoggedIn, redirectUrl: redirectUrl ? redirectUrl : ''})),
-  on(CoreActions.pathRequested, (state, {requestedPath}) => ({...state, requestedPath}))
+  on(CoreActions.pathRequested, (state, {requestedPath}) => ({
+    ...state,
+    requestedPath: excludedPaths.includes(requestedPath) ? '/dashboard' : requestedPath
+  }))
 )

--- a/src/app/reducers/index.ts
+++ b/src/app/reducers/index.ts
@@ -35,7 +35,7 @@ export const reducers: ActionReducerMap<RootState> = {
 };
 
 export function localStorageSyncReducer(reducer: ActionReducer<RootState>): ActionReducer<RootState> {
-  return localStorageSync({keys: [CORE_STATE_KEY], rehydrate: true})(reducer);
+  return localStorageSync({keys: [{ [CORE_STATE_KEY]: ['oidcIssuer', 'requestedPath']}], rehydrate: true})(reducer);
 }
 
 export const metaReducers: MetaReducer<RootState>[] = !ENV.production ? [localStorageSyncReducer] : [localStorageSyncReducer];

--- a/src/app/selectors/ core.selectors.ts
+++ b/src/app/selectors/ core.selectors.ts
@@ -19,6 +19,11 @@ export const webId = createSelector(
   core => core.webId,
 );
 
+export const loginKnown = createSelector(
+  selectCore,
+  core => core.loginKnown
+)
+
 export const loggedInStatus = createSelector(
   selectCore,
   core => core.isLoggedIn,

--- a/src/app/views/navbar/navbar.component.html
+++ b/src/app/views/navbar/navbar.component.html
@@ -3,11 +3,4 @@
     <h3>Solid Authorization Agent</h3>
     <h6 *ngIf="webId">{{webId}}</h6>
   </div>
-  <span class="spacer"></span>
-  <span *ngIf="isServerLoggedIn; else serverLoggedOut"><mat-icon>dns</mat-icon></span>
-  <span class="spacer"></span>
 </mat-toolbar>
-
-<ng-template #serverLoggedOut>
-  <button mat-raised-button (click)="loginServer()">Connect To Server</button>
-</ng-template>

--- a/src/app/views/navbar/navbar.component.ts
+++ b/src/app/views/navbar/navbar.component.ts
@@ -1,8 +1,5 @@
-import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { CoreActions } from 'src/app/actions';
-import {ENV} from "../../../environments/environment";
-import {SolidClient} from "../../utils/solid-client";
 
 @Component({
   selector: 'sai-navbar',
@@ -11,18 +8,11 @@ import {SolidClient} from "../../utils/solid-client";
 })
 export class NavbarComponent implements OnInit {
 
-  @Input() oidcIssuer!: string;
-  @Input() isServerLoggedIn!: boolean;
   @Input() webId!: string | null;
 
   constructor(
-    private solidClient: SolidClient,
-    private store: Store,
-  ) { }
+  ) {}
 
   ngOnInit(): void {}
 
-  loginServer() {
-    this.store.dispatch(CoreActions.serverLoginRequested())
-  }
 }


### PR DESCRIPTION
closes #37 

There must be a cleaner way of doing it but this one seems to work. Most of the logic is captured in the `StartGuard`


I also don't know how to have the start component shown (the spinner) while both authn statuses are being resolved.