### PR TITLE
Directly export actions

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,7 +2,7 @@ import {Component, OnInit} from '@angular/core';
 import {Router} from "@angular/router";
 import {Store} from "@ngrx/store";
 import {onSessionRestore} from '@inrupt/solid-client-authn-browser';
-import {CoreActions} from "./state/actions";
+import * as CoreActions from "./state/actions";
 import {selectLoggedInStatus, selectIssuer, selectWebId} from "./state/selectors";
 import {SwPush} from '@angular/service-worker';
 import {PushService} from "./services/push.service";

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,7 +2,7 @@ import {Component, OnInit} from '@angular/core';
 import {Router} from "@angular/router";
 import {Store} from "@ngrx/store";
 import {onSessionRestore} from '@inrupt/solid-client-authn-browser';
-import * as CoreActions from "./state/actions";
+import * as CoreActions from "./state/actions/core.actions";
 import {selectLoggedInStatus, selectIssuer, selectWebId} from "./state/selectors";
 import {SwPush} from '@angular/service-worker';
 import {PushService} from "./services/push.service";

--- a/src/app/components/add-social-agent/add-social-agent.component.ts
+++ b/src/app/components/add-social-agent/add-social-agent.component.ts
@@ -2,7 +2,7 @@ import {Component, OnInit} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
 import {Store} from "@ngrx/store";
 import {IRI} from "@janeirodigital/sai-api-messages";
-import {DataActions} from "../../state/actions/application.actions";
+import * as DataActions from "../../state/actions/application.actions";
 
 @Component({
   selector: 'sai-add-social-agent',

--- a/src/app/components/applications/applications.component.ts
+++ b/src/app/components/applications/applications.component.ts
@@ -2,7 +2,7 @@ import {Component, OnInit} from '@angular/core';
 import {Store} from "@ngrx/store";
 import {selectApplications} from 'src/app/state/selectors/application.selectors';
 import * as DataActions from 'src/app/state/actions/application.actions';
-import {DescActions} from "../../state/actions/description.actions";
+import * as DescActions from "../../state/actions/description.actions";
 import {
   selectCurrentGroup,
   selectCurrentNeeds,

--- a/src/app/components/applications/applications.component.ts
+++ b/src/app/components/applications/applications.component.ts
@@ -1,7 +1,7 @@
 import {Component, OnInit} from '@angular/core';
 import {Store} from "@ngrx/store";
 import {selectApplications} from 'src/app/state/selectors/application.selectors';
-import {DataActions} from 'src/app/state/actions/application.actions';
+import * as DataActions from 'src/app/state/actions/application.actions';
 import {DescActions} from "../../state/actions/description.actions";
 import {
   selectCurrentGroup,

--- a/src/app/components/authorization/authorization.component.ts
+++ b/src/app/components/authorization/authorization.component.ts
@@ -4,7 +4,7 @@ import {MatTreeNestedDataSource} from '@angular/material/tree';
 import {ActivatedRoute, Router} from '@angular/router';
 import {AccessNeed, AuthorizationData, DataAuthorization, IRI} from '@janeirodigital/sai-api-messages';
 import {Store} from "@ngrx/store";
-import {DescActions} from 'src/app/state/actions/description.actions';
+import * as DescActions from 'src/app/state/actions/description.actions';
 import {selectDescriptions} from 'src/app/state/selectors/description.selectors'
 import * as DataActions from 'src/app/state/actions/application.actions';
 

--- a/src/app/components/authorization/authorization.component.ts
+++ b/src/app/components/authorization/authorization.component.ts
@@ -6,7 +6,7 @@ import {AccessNeed, AuthorizationData, DataAuthorization, IRI} from '@janeirodig
 import {Store} from "@ngrx/store";
 import {DescActions} from 'src/app/state/actions/description.actions';
 import {selectDescriptions} from 'src/app/state/selectors/description.selectors'
-import {DataActions} from 'src/app/state/actions/application.actions';
+import * as DataActions from 'src/app/state/actions/application.actions';
 
 @Component({
   selector: 'sai-authorization',

--- a/src/app/components/connect-server/connect-server.component.ts
+++ b/src/app/components/connect-server/connect-server.component.ts
@@ -1,6 +1,6 @@
 import {Component} from '@angular/core';
 import {Store} from '@ngrx/store'
-import * as CoreActions from 'src/app/state/actions';
+import * as CoreActions from 'src/app/state/actions/core.actions';
 
 @Component({
   selector: 'sai-connect-server',

--- a/src/app/components/connect-server/connect-server.component.ts
+++ b/src/app/components/connect-server/connect-server.component.ts
@@ -1,6 +1,6 @@
 import {Component} from '@angular/core';
 import {Store} from '@ngrx/store'
-import {CoreActions} from 'src/app/state/actions';
+import * as CoreActions from 'src/app/state/actions';
 
 @Component({
   selector: 'sai-connect-server',

--- a/src/app/components/data/data.component.ts
+++ b/src/app/components/data/data.component.ts
@@ -1,6 +1,6 @@
 import {Component, OnInit} from '@angular/core';
 import {Store} from "@ngrx/store";
-import {DataActions} from 'src/app/state/actions/application.actions';
+import * as DataActions from 'src/app/state/actions/application.actions';
 import {selectDataRegistries} from 'src/app/state/selectors/data.selectors';
 import {Observable} from "rxjs";
 import {DataRegistry} from "@janeirodigital/sai-api-messages";

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -1,7 +1,7 @@
 import {Component} from '@angular/core';
 import {UntypedFormControl, UntypedFormGroup} from '@angular/forms';
 import {Store} from "@ngrx/store";
-import {CoreActions} from "../../state/actions";
+import * as CoreActions from "../../state/actions/core.actions";
 import {ENV} from "../../../environments/environment";
 
 @Component({

--- a/src/app/components/redirect-handler/redirect-handler.component.ts
+++ b/src/app/components/redirect-handler/redirect-handler.component.ts
@@ -1,7 +1,7 @@
 import {Component, OnInit} from '@angular/core';
 import {Router} from "@angular/router";
 import {Store} from "@ngrx/store";
-import * as CoreActions from "../../state/actions";
+import * as CoreActions from "../../state/actions/core.actions";
 
 @Component({
   selector: 'sai-redirect-handler',

--- a/src/app/components/redirect-handler/redirect-handler.component.ts
+++ b/src/app/components/redirect-handler/redirect-handler.component.ts
@@ -1,7 +1,7 @@
 import {Component, OnInit} from '@angular/core';
 import {Router} from "@angular/router";
 import {Store} from "@ngrx/store";
-import {CoreActions} from "../../state/actions";
+import * as CoreActions from "../../state/actions";
 
 @Component({
   selector: 'sai-redirect-handler',

--- a/src/app/components/social-agents/social-agents.component.ts
+++ b/src/app/components/social-agents/social-agents.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Store } from "@ngrx/store";
 import { selectSocialAgents } from 'src/app/state/selectors/social-agent.selectors';
-import { DataActions } from 'src/app/state/actions/application.actions';
+import  * as DataActions from 'src/app/state/actions/application.actions';
 import {Observable} from "rxjs";
 import {SocialAgent} from "@janeirodigital/sai-api-messages";
 

--- a/src/app/guards/auth.guard.service.ts
+++ b/src/app/guards/auth.guard.service.ts
@@ -3,7 +3,7 @@ import {ActivatedRouteSnapshot, CanActivateChild, Router, RouterStateSnapshot, U
 import {from, map, tap, switchMap, Observable, withLatestFrom} from 'rxjs';
 import {getDefaultSession} from '@inrupt/solid-client-authn-browser';
 import {Store} from "@ngrx/store";
-import {CoreActions} from "../state/actions";
+import * as CoreActions from "../state/actions";
 import {selectBothEndsLoggedIn, selectLoggedInStatus} from "../state/selectors"
 
 @Injectable({

--- a/src/app/guards/auth.guard.service.ts
+++ b/src/app/guards/auth.guard.service.ts
@@ -3,7 +3,7 @@ import {ActivatedRouteSnapshot, CanActivateChild, Router, RouterStateSnapshot, U
 import {from, map, tap, switchMap, Observable, withLatestFrom} from 'rxjs';
 import {getDefaultSession} from '@inrupt/solid-client-authn-browser';
 import {Store} from "@ngrx/store";
-import * as CoreActions from "../state/actions";
+import * as CoreActions from "../state/actions/core.actions";
 import {selectBothEndsLoggedIn, selectLoggedInStatus} from "../state/selectors"
 
 @Injectable({

--- a/src/app/interceptors/auth.interceptor.ts
+++ b/src/app/interceptors/auth.interceptor.ts
@@ -8,7 +8,7 @@ import {
   HttpEventType
 } from '@angular/common/http';
 import { Observable, tap} from 'rxjs';
-import { CoreActions } from '../state/actions';
+import * as CoreActions from '../state/actions';
 import { Store } from '@ngrx/store';
 
 @Injectable()

--- a/src/app/interceptors/auth.interceptor.ts
+++ b/src/app/interceptors/auth.interceptor.ts
@@ -8,7 +8,7 @@ import {
   HttpEventType
 } from '@angular/common/http';
 import { Observable, tap} from 'rxjs';
-import * as CoreActions from '../state/actions';
+import * as CoreActions from '../state/actions/core.actions';
 import { Store } from '@ngrx/store';
 
 @Injectable()

--- a/src/app/state/actions/application.actions.ts
+++ b/src/app/state/actions/application.actions.ts
@@ -1,68 +1,54 @@
 import { createAction, props } from '@ngrx/store';
 import { Application, DataRegistry, IRI, SocialAgent, Authorization, AccessAuthorization } from '@janeirodigital/sai-api-messages';
 
-const applicationsPanelLoaded = createAction(
+export const applicationsPanelLoaded = createAction(
   '[APPLICATION PROFILES] Application Profiles Requested'
 );
 
-const applicationProfilesReceived = createAction(
+export const applicationProfilesReceived = createAction(
   '[APPLICATION PROFILES] Application Profiles Received',
   props<{profiles: Application[]}>(),
 )
 
-const applicationProfileReceived = createAction(
+export const applicationProfileReceived = createAction(
   '[APPLICATION PROFILES] Adding Single Application Profile',
   props<{profile: Application}>(),
 )
 
-const socialAgentsPanelLoaded = createAction(
+export const socialAgentsPanelLoaded = createAction(
   '[SOCIAL AGENT PROFILES] Social Agent Profiles Requested'
 );
 
-const socialAgentProfilesReceived = createAction(
+export const socialAgentProfilesReceived = createAction(
   '[SOCIAL AGENT PROFILES] Social Agent Profiles Received',
   props<{profiles: SocialAgent[]}>(),
 )
 
-const addSocialAgent = createAction(
+export const addSocialAgent = createAction(
   '[SOCIAL AGENT PROFILES] Add Social Agent',
   props<{webId: IRI, label: string, note?: string}>()
 )
 
-const socialAgentProfileReceived = createAction(
+export const socialAgentProfileReceived = createAction(
   '[SOCIAL AGENT PROFILES] Single Social Agent Profile Received',
   props<{profile: SocialAgent}>(),
 )
 
-const dataRegistriesNeeded = createAction(
+export const dataRegistriesNeeded = createAction(
   '[DATA REGISTRIES] Data Registries Requested'
 );
 
-const dataRegistriesProvided = createAction(
+export const dataRegistriesProvided = createAction(
   '[DATA REGISTRIES] Data Registries Received',
   props<{registries: DataRegistry[]}>(),
 )
 
-const authorizeApplication = createAction(
+export const authorizeApplication = createAction(
   '[APPLICATION PROFILES] Authorize Application',
   props<{ authorization: Authorization }>()
 )
 
-const authorizationReceived = createAction(
+export const authorizationReceived = createAction(
   '[APPLICATION PROFILES] Authorization Received',
   props<{ accessAuthorization: AccessAuthorization }>()
 )
-
-export const DataActions = {
-  applicationsPanelLoaded,
-  applicationProfilesReceived,
-  applicationProfileReceived,
-  socialAgentsPanelLoaded,
-  socialAgentProfilesReceived,
-  addSocialAgent,
-  socialAgentProfileReceived,
-  dataRegistriesNeeded,
-  dataRegistriesProvided,
-  authorizeApplication,
-  authorizationReceived,
-}

--- a/src/app/state/actions/core.actions.ts
+++ b/src/app/state/actions/core.actions.ts
@@ -2,7 +2,7 @@
 import { ISessionInfo } from '@inrupt/solid-client-authn-browser';
 import {createAction, props} from '@ngrx/store';
 
-const loginRequested = createAction(
+export const loginRequested = createAction(
   '[CORE] Login Requested',
   props<{oidcIssuer: string}>(),
 );
@@ -10,73 +10,58 @@ const loginRequested = createAction(
 /**
  * Marks that the navigations has been handled off to the user IDP
  */
-const loginInitiated = createAction(
+export const loginInitiated = createAction(
   '[CORE] Login Initiated',
    props<{oidcIssuer: string}>(),
 );
 
 // `url`- full url of incoming redirect
-const incomingLoginRedirect = createAction(
+export const incomingLoginRedirect = createAction(
   '[CORE] Incoming Login Redirect',
   props<{url: string}>(),
 );
 
-const oidcInfoReceived = createAction(
+export const oidcInfoReceived = createAction(
   '[CORE] OIDC Info Received',
   props<{oidcInfo: ISessionInfo}>(),
 );
 
-const webIdReceived = createAction(
+export const webIdReceived = createAction(
   '[CORE] WebId Received',
   props<{webId: string}>(),
 )
 
-const loginStatusChanged = createAction(
+export const loginStatusChanged = createAction(
   '[CORE] Login Status Changed',
   props<{loggedIn: boolean}>(),
 )
 
-const serverSessionRequested = createAction(
+export const serverSessionRequested = createAction(
   '[CORE] Server session status requested',
   props<{oidcIssuer: string}>(),
 )
 
-const serverSessionReceived = createAction(
+export const serverSessionReceived = createAction(
   '[CORE] Server session status received',
   props<{isServerLoggedIn: boolean, redirectUrl?: string}>(),
 )
 
-const pathRequested = createAction(
+export const pathRequested = createAction(
   '[CORE] Path requested',
   props<{requestedPath: string}>()
 )
 
-const requestName = createAction(
+export const requestName = createAction(
   '[CORE] Request Name',
 )
 
-const serverLoginRequested = createAction(
+export const serverLoginRequested = createAction(
   '[CORE] Server Login Requested'
 );
 
 /**
  * Marks that the navigations has been handled off to the user IDP
  */
-const serverLoginInitiated = createAction(
+export const serverLoginInitiated = createAction(
   '[CORE] Server login Initiated'
 );
-
-export const CoreActions = {
-  loginRequested,
-  loginInitiated,
-  incomingLoginRedirect,
-  oidcInfoReceived,
-  webIdReceived,
-  loginStatusChanged,
-  serverSessionRequested,
-  serverSessionReceived,
-  pathRequested,
-  requestName,
-  serverLoginRequested,
-  serverLoginInitiated
-};

--- a/src/app/state/actions/description.actions.ts
+++ b/src/app/state/actions/description.actions.ts
@@ -1,17 +1,12 @@
 import {createAction, props} from "@ngrx/store";
 import { AuthorizationData } from '@janeirodigital/sai-api-messages'
 
-const descriptionsNeeded = createAction(
+export const descriptionsNeeded = createAction(
   '[DESCRIPTIONS] Descriptions needed for application',
   props<{applicationId: string}>(),
 );
 
-const descriptionsReceived = createAction(
+export const descriptionsReceived = createAction(
   '[DESCRIPTIONS] Descriptions received for application',
   props<{authorizationData: AuthorizationData}>(),
 )
-
-export const DescActions = {
-  descriptionsNeeded,
-  descriptionsReceived,
-}

--- a/src/app/state/actions/index.ts
+++ b/src/app/state/actions/index.ts
@@ -1,2 +1,0 @@
-
-export * from './core.actions';

--- a/src/app/state/effects/application.effects.ts
+++ b/src/app/state/effects/application.effects.ts
@@ -2,7 +2,7 @@ import {map, mergeMap, switchMap, tap} from "rxjs";
 import {Injectable} from "@angular/core";
 import {Actions, concatLatestFrom, createEffect, ofType} from "@ngrx/effects";
 import * as DataActions from "../actions/application.actions";
-import {DescActions} from "../actions/description.actions";
+import * as DescActions from "../actions/description.actions";
 import * as NeedActions from "../actions/access-needs.actions"
 import {DataService} from "../../services/data.service";
 import {Store} from "@ngrx/store";

--- a/src/app/state/effects/application.effects.ts
+++ b/src/app/state/effects/application.effects.ts
@@ -1,7 +1,7 @@
 import {map, mergeMap, switchMap, tap} from "rxjs";
 import {Injectable} from "@angular/core";
 import {Actions, concatLatestFrom, createEffect, ofType} from "@ngrx/effects";
-import {DataActions} from "../actions/application.actions";
+import * as DataActions from "../actions/application.actions";
 import {DescActions} from "../actions/description.actions";
 import * as NeedActions from "../actions/access-needs.actions"
 import {DataService} from "../../services/data.service";

--- a/src/app/state/effects/core.effects.ts
+++ b/src/app/state/effects/core.effects.ts
@@ -3,7 +3,7 @@ import {Actions, createEffect, ofType, concatLatestFrom} from "@ngrx/effects";
 import { Store } from "@ngrx/store";
 import { EMPTY, map, tap, of, from} from "rxjs";
 import {LoginService} from "../../services/login.service";
-import {CoreActions} from "../actions";
+import * as CoreActions from "../actions";
 import {mergeMap} from "rxjs/operators";
 import * as selectors from "../selectors";
 

--- a/src/app/state/effects/core.effects.ts
+++ b/src/app/state/effects/core.effects.ts
@@ -3,7 +3,7 @@ import {Actions, createEffect, ofType, concatLatestFrom} from "@ngrx/effects";
 import { Store } from "@ngrx/store";
 import { EMPTY, map, tap, of, from} from "rxjs";
 import {LoginService} from "../../services/login.service";
-import * as CoreActions from "../actions";
+import * as CoreActions from "../actions/core.actions";
 import {mergeMap} from "rxjs/operators";
 import * as selectors from "../selectors";
 

--- a/src/app/state/reducers/application.reducer.ts
+++ b/src/app/state/reducers/application.reducer.ts
@@ -1,6 +1,6 @@
 import {createReducer, on} from '@ngrx/store';
 import {Application, IRI} from '@janeirodigital/sai-api-messages';
-import {DataActions} from "../actions/application.actions";
+import * as DataActions from "../actions/application.actions";
 import {createEntityAdapter, EntityState} from "@ngrx/entity";
 
 export const APPLICATION_PROFILE_STATE_KEY = 'applications';

--- a/src/app/state/reducers/core.reducer.ts
+++ b/src/app/state/reducers/core.reducer.ts
@@ -1,5 +1,5 @@
 import {createReducer, on} from "@ngrx/store";
-import * as CoreActions from "../actions";
+import * as CoreActions from "../actions/core.actions";
 
 export const CORE_STATE_KEY = 'core';
 export const CORE_LANGUAGE_KEY = 'coreLanguage';

--- a/src/app/state/reducers/core.reducer.ts
+++ b/src/app/state/reducers/core.reducer.ts
@@ -1,5 +1,5 @@
 import {createReducer, on} from "@ngrx/store";
-import {CoreActions} from "../actions";
+import * as CoreActions from "../actions";
 
 export const CORE_STATE_KEY = 'core';
 export const CORE_LANGUAGE_KEY = 'coreLanguage';

--- a/src/app/state/reducers/data-registry.reducer.ts
+++ b/src/app/state/reducers/data-registry.reducer.ts
@@ -1,7 +1,7 @@
 import {createReducer, on} from '@ngrx/store';
 import { NormalizedState } from "./index";
 import {DataRegistry} from '@janeirodigital/sai-api-messages';
-import {DataActions} from "../actions/application.actions";
+import * as DataActions from "../actions/application.actions";
 import {insertEntities} from "./utils";
 
 export const DATA_REGISTRY_STATE_KEY = 'data';

--- a/src/app/state/reducers/descriptions.reducer.ts
+++ b/src/app/state/reducers/descriptions.reducer.ts
@@ -1,7 +1,7 @@
 import {NormalizedState} from "./index";
 import {createReducer, on} from "@ngrx/store";
 import {AuthorizationData, IRI} from "@janeirodigital/sai-api-messages";
-import {DescActions} from "../actions/description.actions";
+import * as DescActions from "../actions/description.actions";
 import {insertEntity} from "./utils";
 
 /*

--- a/src/app/state/reducers/social-agent.reducer.ts
+++ b/src/app/state/reducers/social-agent.reducer.ts
@@ -1,6 +1,7 @@
 import {createReducer, on} from '@ngrx/store';
 import {SocialAgent} from '@janeirodigital/sai-api-messages';
-import {DataActions} from "../actions/application.actions";
+// TODO why are `DATA`actions imported from `APPLICATION`.actions in the `SOCIAL_AGENTS`.reducer?
+import * as DataActions from "../actions/application.actions";
 import {createEntityAdapter, EntityState} from "@ngrx/entity";
 
 export const SOCIAL_AGENT_STATE_KEY = 'social-agents';


### PR DESCRIPTION
Grouping actions in an renamed object obstructs static code analysis. Exporting individually and importing them as a single group fixes this with the benefit of knowing which actions are unused, and code navigation to where they are used in dispatches and reducers.